### PR TITLE
Remove shebang and run python directly

### DIFF
--- a/envirou
+++ b/envirou
@@ -1,15 +1,22 @@
 #!/bin/bash
+# This script is sourced from bash or zsh so it can't assume bash
 
 if [ -n "${ZSH_VERSION}" ] ; then
     if [ -n "$(readlink ${(%):-%x})" ] ; then
-        eval $(env | python "$(dirname $(readlink ${(%):-%x}))/envirou.py" $*)
+        _envirou_py_location="$(dirname $(readlink ${(%):-%x}))/envirou.py"
     else
-        eval $(env | python "$(dirname ${(%):-%x})/envirou.py" $*)
+        _envirou_py_location="$(dirname ${(%):-%x})/envirou.py"
     fi
 else
     if [ -n "$(readlink ${BASH_SOURCE[0]})" ] ; then
-        eval $(env | python "$(dirname $(readlink ${BASH_SOURCE[0]}))/envirou.py" $*)
+        _envirou_py_location="$(dirname $(readlink ${BASH_SOURCE[0]}))/envirou.py"
     else
-        eval $(env | python "$(dirname ${BASH_SOURCE[0]})/envirou.py" $*)
+        _envirou_py_location="$(dirname ${BASH_SOURCE[0]})/envirou.py"
     fi
+fi
+
+if which python3 >/dev/null ; then
+    eval $(env | python3 $_envirou_py_location $*)
+else
+    eval $(env | python $_envirou_py_location $*)
 fi

--- a/envirou.py
+++ b/envirou.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from __future__ import print_function
 import argparse
 import os


### PR DESCRIPTION
The shebang was confusing windows and to support python3 we need to run the process directly anyway.