### PR TITLE
Add path prepend/append operators and improve set command feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,16 +159,16 @@ can create different profiles that for example have a different default namespac
 
 ```inifile
 [profile:basic]
-PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/sab/src/custom/bin
+PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 VIRTUAL_ENV
 AWS_PROFILE
 
 [profile:py3]
-PATH=/Users/sab/sdk/py3/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/sab/src/custom/bin
+PATH^=/Users/sab/sdk/py3/bin
 VIRTUAL_ENV=/Users/sab/sdk/py3
 
 [profile:py2]
-PATH=/Users/sab/sdk/py2/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/sab/src/custom/bin
+PATH^=/Users/sab/sdk/py2/bin
 VIRTUAL_ENV=/Users/sab/sdk/py2
 
 [profile:awsprod]
@@ -180,7 +180,7 @@ AWS_PROFILE=dev
 
 Now you can switch profiles by running `ev set py3 awsprod`.
 
-See the [profiles guide](./docs/profiles.md) for more details on creating and using profiles.
+See the [profiles guide](./docs/profiles.md) for more details on creating and using profiles, including `^=` (prepend) and `+=` (append) operators for PATH-like variables.
 
 
 ## Where does the name come from?

--- a/TODO.md
+++ b/TODO.md
@@ -7,12 +7,6 @@ Support profile dependencies — if activating `profileX`, automatically import 
 first. This enables an `init` profile that always runs as a baseline, and layered profiles
 that build on each other (e.g., `ev set aws-prod` could automatically chain a base `aws` profile).
 
-### Base variables for paths
-Store a base PATH (or other path-like variables) in the environment using a reserved prefix
-(e.g., `_ENVIROU_BASE_PATH`). Profiles can then append/prepend to the base rather than
-storing the full path. This makes switching Python virtualenvs or SDK versions cleaner —
-profiles only specify the delta, not the entire PATH.
-
 ### Improve config editing
 Make the config file easier to read and modify. Ideas:
 - Validate config on save

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -11,6 +11,11 @@ import (
 	"github.com/sverrirab/envirou/pkg/config"
 )
 
+// tp joins path components with the platform path separator.
+func tp(parts ...string) string {
+	return strings.Join(parts, string(os.PathListSeparator))
+}
+
 const testConfigForCmd = `
 [settings]
 quiet=1
@@ -452,7 +457,7 @@ func TestFindNameValueMutuallyExclusive(t *testing.T) {
 // --- Prepend/Append tests ---
 
 func TestSetPrependProfile(t *testing.T) {
-	t.Setenv("TEST_PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("TEST_PATH", tp("/usr/local/bin", "/usr/bin", "/bin"))
 	out := executeCommand(t, "set", "venv")
 	if !strings.Contains(out, "TEST_PATH") {
 		t.Errorf("Expected TEST_PATH in output, got: %s", out)
@@ -464,7 +469,7 @@ func TestSetPrependProfile(t *testing.T) {
 }
 
 func TestSetAppendProfile(t *testing.T) {
-	t.Setenv("TEST_PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("TEST_PATH", tp("/usr/local/bin", "/usr/bin", "/bin"))
 	out := executeCommand(t, "set", "tools")
 	if !strings.Contains(out, "TEST_PATH") {
 		t.Errorf("Expected TEST_PATH in output, got: %s", out)
@@ -476,7 +481,7 @@ func TestSetAppendProfile(t *testing.T) {
 
 func TestSetPrependAlreadyPresent(t *testing.T) {
 	// Component already in path — should be a no-op for that var
-	t.Setenv("TEST_PATH", "/home/user/venv/bin:/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("TEST_PATH", tp("/home/user/venv/bin", "/usr/local/bin", "/usr/bin", "/bin"))
 	t.Setenv("VIRTUAL_ENV", "/home/user/venv")
 	out := executeCommand(t, "set", "venv")
 	// TEST_PATH should not change (component already present)
@@ -487,7 +492,7 @@ func TestSetPrependAlreadyPresent(t *testing.T) {
 }
 
 func TestSetPrependAndAppendCombined(t *testing.T) {
-	t.Setenv("TEST_PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("TEST_PATH", tp("/usr/local/bin", "/usr/bin", "/bin"))
 	out := executeCommand(t, "set", "venv", "tools")
 	// Both should be applied
 	if !strings.Contains(out, "/home/user/venv/bin") {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -24,6 +24,13 @@ TEST_ENV=development
 [profile:prod]
 TEST_ENV=production
 TEST_DEBUG
+
+[profile:venv]
+TEST_PATH^=/home/user/venv/bin
+VIRTUAL_ENV=/home/user/venv
+
+[profile:tools]
+TEST_PATH+=/opt/tools/bin
 `
 
 // executeCommand sets up a test config, resets global state, and executes
@@ -211,11 +218,12 @@ func TestSetPartialMissing(t *testing.T) {
 func TestProfilesList(t *testing.T) {
 	_ = executeCommand(t, "profiles")
 	// Verify profiles were populated from config
-	if len(app.profileNames) != 2 {
-		t.Errorf("Expected 2 profiles, got %d: %v", len(app.profileNames), app.profileNames)
+	if len(app.profileNames) != 4 {
+		t.Errorf("Expected 4 profiles, got %d: %v", len(app.profileNames), app.profileNames)
 	}
-	if !contains(app.profileNames, "dev") || !contains(app.profileNames, "prod") {
-		t.Errorf("Expected dev and prod profiles, got: %v", app.profileNames)
+	if !contains(app.profileNames, "dev") || !contains(app.profileNames, "prod") ||
+		!contains(app.profileNames, "venv") || !contains(app.profileNames, "tools") {
+		t.Errorf("Expected dev, prod, venv, tools profiles, got: %v", app.profileNames)
 	}
 }
 
@@ -438,5 +446,54 @@ func TestFindNameValueMutuallyExclusive(t *testing.T) {
 	err := rootCmd.Execute()
 	if err == nil {
 		t.Error("Expected error when both --name and --value are set")
+	}
+}
+
+// --- Prepend/Append tests ---
+
+func TestSetPrependProfile(t *testing.T) {
+	t.Setenv("TEST_PATH", "/usr/local/bin:/usr/bin:/bin")
+	out := executeCommand(t, "set", "venv")
+	if !strings.Contains(out, "TEST_PATH") {
+		t.Errorf("Expected TEST_PATH in output, got: %s", out)
+	}
+	// Should prepend venv bin to existing path
+	if !strings.Contains(out, "/home/user/venv/bin") {
+		t.Errorf("Expected prepended path in output, got: %s", out)
+	}
+}
+
+func TestSetAppendProfile(t *testing.T) {
+	t.Setenv("TEST_PATH", "/usr/local/bin:/usr/bin:/bin")
+	out := executeCommand(t, "set", "tools")
+	if !strings.Contains(out, "TEST_PATH") {
+		t.Errorf("Expected TEST_PATH in output, got: %s", out)
+	}
+	if !strings.Contains(out, "/opt/tools/bin") {
+		t.Errorf("Expected appended path in output, got: %s", out)
+	}
+}
+
+func TestSetPrependAlreadyPresent(t *testing.T) {
+	// Component already in path — should be a no-op for that var
+	t.Setenv("TEST_PATH", "/home/user/venv/bin:/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("VIRTUAL_ENV", "/home/user/venv")
+	out := executeCommand(t, "set", "venv")
+	// TEST_PATH should not change (component already present)
+	// VIRTUAL_ENV already matches — no shell command needed
+	if strings.Contains(out, "TEST_PATH") {
+		t.Errorf("Expected no TEST_PATH change when component already present, got: %s", out)
+	}
+}
+
+func TestSetPrependAndAppendCombined(t *testing.T) {
+	t.Setenv("TEST_PATH", "/usr/local/bin:/usr/bin:/bin")
+	out := executeCommand(t, "set", "venv", "tools")
+	// Both should be applied
+	if !strings.Contains(out, "/home/user/venv/bin") {
+		t.Errorf("Expected prepended venv path, got: %s", out)
+	}
+	if !strings.Contains(out, "/opt/tools/bin") {
+		t.Errorf("Expected appended tools path, got: %s", out)
 	}
 }

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -24,17 +24,34 @@ To change profiles edit the config file (see "config" command)`,
 	Run: func(cmd *cobra.Command, args []string) {
 		newEnv := app.baseEnv.Clone()
 		var notFound []string
+		var alreadyActive []string
 		for _, activateName := range args {
 			profile, found := findProfile(app.out, app.configuration, activateName)
-			if found {
-				newEnv.Merge(profile)
-				output.Printf("Profile %s enabled\n", app.out.ProfileSprintf(activateName))
-			} else {
+			if !found {
 				notFound = append(notFound, activateName)
+				continue
+			}
+			wasActive := app.baseEnv.IsMerged(profile)
+			result := newEnv.Merge(profile)
+			if wasActive {
+				alreadyActive = append(alreadyActive, activateName)
+			} else {
+				suffix := ""
+				if len(result.PathSkipped) > 0 {
+					suffix = " (* " + strings.Join(result.PathSkipped, ", ") + " already in path)"
+				}
+				output.Printf("Profile %s enabled%s\n", app.out.ProfileSprintf(activateName), suffix)
 			}
 		}
+		if len(alreadyActive) > 0 {
+			colored := make([]string, len(alreadyActive))
+			for i, name := range alreadyActive {
+				colored[i] = app.out.ProfileSprintf(name)
+			}
+			output.Printf("Already active: %s\n", strings.Join(colored, ", "))
+		}
 		if len(notFound) > 0 {
-			output.Printf("Warning: %d of %d profiles not found, skipped: %s\n", len(notFound), len(args), strings.Join(notFound, ", "))
+			output.Printf("Warning: profiles not found: %s\n", strings.Join(notFound, ", "))
 		}
 		app.shellCommands = append(app.shellCommands, app.sh.GetCommands(app.baseEnv, newEnv)...)
 	},

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -23,6 +23,37 @@ Variables can have three states in a profile:
 - `KEY=` — set the variable to an empty string
 - `KEY` — unset (remove) the variable
 
+### Path operators (prepend and append)
+
+For PATH-like variables, you can use `^=` to prepend or `+=` to append instead of replacing the entire value:
+
+| Operator | Syntax | Description |
+|----------|--------|-------------|
+| Replace | `VAR=value` | Set the variable to an exact value (default) |
+| Prepend | `VAR^=value` | Prepend to a path-like variable |
+| Append | `VAR+=value` | Append to a path-like variable |
+
+These operators split on the platform path separator (`:` on Unix, `;` on Windows) and **deduplicate**: if a component already exists anywhere in the current value, it is skipped. This means applying the same profile twice is safe — envirou will report "already active" and make no changes.
+
+Example:
+```ini
+[profile:py3]
+PATH^=/Users/you/envs/py3/bin
+VIRTUAL_ENV=/Users/you/envs/py3
+```
+
+If your PATH is `/usr/local/bin:/usr/bin:/bin`, running `ev set py3` produces:
+```
+PATH=/Users/you/envs/py3/bin:/usr/local/bin:/usr/bin:/bin
+```
+
+You can prepend multiple components at once:
+```ini
+PATH^=/a:/b
+```
+
+**Note:** `ev diff --save` always writes profiles using `=` (full replacement), since it captures the exact environment state rather than the delta. You can manually edit saved profiles to use `^=` or `+=` if desired.
+
 ## Activating profiles
 
 ```bash
@@ -80,7 +111,7 @@ AWS_PROFILE=prod
 AWS_DEFAULT_REGION=eu-west-1
 
 [profile:py3]
-PATH=/Users/you/envs/py3/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+PATH^=/Users/you/envs/py3/bin
 VIRTUAL_ENV=/Users/you/envs/py3
 ```
 
@@ -92,4 +123,4 @@ ev set py3 awsdev         # Python 3 + AWS dev
 ev set py3 awsprod        # Python 3 + AWS prod
 ```
 
-The `basic` profile unsets `VIRTUAL_ENV` and `AWS_PROFILE` (note the bare variable names without `=`), giving you a clean slate.
+The `basic` profile unsets `VIRTUAL_ENV` and `AWS_PROFILE` (note the bare variable names without `=`), giving you a clean slate. The `py3` profile uses `^=` to prepend to PATH rather than replacing it entirely — no need to hardcode the full path.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -86,7 +86,15 @@ func ReadConfiguration(configPath string, caseInsensitive bool) (*Configuration,
 				if config.IsNil(section, entry) {
 					profile.SetNil(entry)
 				} else {
-					profile.Set(entry, config.GetString(section, entry, ""))
+					op := config.GetOperator(section, entry)
+					mode := data.MergeReplace
+					switch op {
+					case ini.OpPrepend:
+						mode = data.MergePrepend
+					case ini.OpAppend:
+						mode = data.MergeAppend
+					}
+					profile.SetWithMode(entry, config.GetString(section, entry, ""), mode)
 				}
 			}
 			configuration.Profiles[profileName] = *profile

--- a/pkg/data/profile.go
+++ b/pkg/data/profile.go
@@ -1,14 +1,23 @@
 package data
 
 import (
+	"os"
 	"sort"
 	"strings"
+)
+
+// MergeMode indicates how a variable should be merged.
+const (
+	MergeReplace = iota // Default: replace entire value
+	MergePrepend        // Prepend to path-like variable
+	MergeAppend         // Append to path-like variable
 )
 
 type Profile struct {
 	env             map[string]string // The actual key value pair
 	rightCase       map[string]string // VAR -> Var (maps to actual case, used for case insensitive comparison on Windows)
 	isNil           map[string]bool   // True if item is to be removed (uses UPPER case name)
+	mergeMode       map[string]int    // MergeReplace, MergePrepend, or MergeAppend per variable
 	caseInsensitive bool
 }
 type Profiles map[string]Profile
@@ -18,6 +27,7 @@ func NewProfile(caseInsensitive bool) *Profile {
 		env:             make(map[string]string),
 		rightCase:       make(map[string]string),
 		isNil:           make(map[string]bool),
+		mergeMode:       make(map[string]int),
 		caseInsensitive: caseInsensitive,
 	}
 }
@@ -35,11 +45,26 @@ func (profile *Profile) GetCorrectCase(name string, create bool) string {
 	return name
 }
 
-// Set will set an entry
+// Set will set an entry (replace mode)
 func (profile *Profile) Set(name string, value string) {
+	profile.SetWithMode(name, value, MergeReplace)
+}
+
+// SetWithMode sets an entry with a specific merge mode.
+func (profile *Profile) SetWithMode(name string, value string, mode int) {
 	correctCase := profile.GetCorrectCase(name, true)
 	profile.env[correctCase] = value
+	profile.mergeMode[correctCase] = mode
 	delete(profile.isNil, correctCase)
+}
+
+// GetMergeMode returns the merge mode for a variable.
+func (profile *Profile) GetMergeMode(name string) int {
+	correctCase := profile.GetCorrectCase(name, false)
+	if mode, ok := profile.mergeMode[correctCase]; ok {
+		return mode
+	}
+	return MergeReplace
 }
 
 // SetNil will mark entry as nil
@@ -93,30 +118,134 @@ func (profile *Profile) Clone() *Profile {
 	for k, v := range profile.isNil {
 		p.isNil[k] = v
 	}
+	for k, v := range profile.mergeMode {
+		p.mergeMode[k] = v
+	}
 	return p
 }
 
+// MergeResult describes what happened during a merge.
+type MergeResult struct {
+	// PathSkipped lists variable names where all components already existed
+	// but not in the expected position (prepend/append was a no-op).
+	PathSkipped []string
+}
+
 // Merge applies all elements from p into current profile.
-func (profile *Profile) Merge(p *Profile) {
+// For prepend/append modes, path components are split on os.PathListSeparator.
+// If a component already exists anywhere in the current value, it is skipped (no-op).
+func (profile *Profile) Merge(p *Profile) MergeResult {
+	result := MergeResult{}
+	sep := string(os.PathListSeparator)
 	for k, v := range p.env {
-		profile.Set(k, v)
+		mode := p.GetMergeMode(k)
+		switch mode {
+		case MergePrepend, MergeAppend:
+			existing, _ := profile.Get(k)
+			merged, allSkipped := mergePathComponents(existing, v, sep, mode)
+			profile.Set(k, merged)
+			if allSkipped && existing != "" {
+				result.PathSkipped = append(result.PathSkipped, k)
+			}
+		default:
+			profile.Set(k, v)
+		}
 	}
 	for k := range p.isNil {
 		profile.SetNil(k)
 	}
+	return result
 }
 
-// IsMerged checkes if profile has already been merged
+// mergePathComponents merges new path components into an existing path-like value.
+// Components already present anywhere in existing are skipped.
+// Returns the merged string and whether all components were already present (allSkipped).
+func mergePathComponents(existing, addition, sep string, mode int) (string, bool) {
+	existingParts := splitPath(existing, sep)
+	newParts := splitPath(addition, sep)
+
+	// Build a set of existing components for fast lookup
+	existingSet := make(map[string]bool, len(existingParts))
+	for _, p := range existingParts {
+		existingSet[p] = true
+	}
+
+	// Filter out components that already exist
+	toAdd := make([]string, 0, len(newParts))
+	for _, p := range newParts {
+		if !existingSet[p] {
+			toAdd = append(toAdd, p)
+		}
+	}
+
+	if len(toAdd) == 0 {
+		return existing, true
+	}
+
+	switch mode {
+	case MergePrepend:
+		return strings.Join(append(toAdd, existingParts...), sep), false
+	case MergeAppend:
+		return strings.Join(append(existingParts, toAdd...), sep), false
+	}
+	return existing, false
+}
+
+// splitPath splits a path string, filtering out empty components.
+func splitPath(s, sep string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, sep)
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+// IsMerged checks if profile has already been merged.
+// For prepend/append variables, checks if all components are present anywhere in the current value.
 func (profile *Profile) IsMerged(p *Profile) bool {
+	sep := string(os.PathListSeparator)
 	for k, v := range p.env {
 		value, exists := profile.Get(k)
-		if !exists || value != v {
+		if !exists {
 			return false
+		}
+		mode := p.GetMergeMode(k)
+		switch mode {
+		case MergePrepend, MergeAppend:
+			if !pathContainsAll(value, v, sep) {
+				return false
+			}
+		default:
+			if value != v {
+				return false
+			}
 		}
 	}
 	for k := range p.isNil {
 		_, exists := profile.Get(k)
 		if exists {
+			return false
+		}
+	}
+	return true
+}
+
+// pathContainsAll returns true if all components of required are present in current.
+func pathContainsAll(current, required, sep string) bool {
+	currentParts := splitPath(current, sep)
+	requiredParts := splitPath(required, sep)
+	currentSet := make(map[string]bool, len(currentParts))
+	for _, p := range currentParts {
+		currentSet[p] = true
+	}
+	for _, p := range requiredParts {
+		if !currentSet[p] {
 			return false
 		}
 	}

--- a/pkg/data/profile_test.go
+++ b/pkg/data/profile_test.go
@@ -151,6 +151,123 @@ func TestFullDiffEmpty(t *testing.T) {
 	}
 }
 
+func TestMergePrepend(t *testing.T) {
+	env := NewProfile(false)
+	env.Set("PATH", "/usr/local/bin:/usr/bin:/bin")
+
+	profile := NewProfile(false)
+	profile.SetWithMode("PATH", "/home/user/venv/bin", MergePrepend)
+
+	env.Merge(profile)
+	verifyValue(t, env, "PATH", "/home/user/venv/bin:/usr/local/bin:/usr/bin:/bin")
+}
+
+func TestMergeAppend(t *testing.T) {
+	env := NewProfile(false)
+	env.Set("PATH", "/usr/local/bin:/usr/bin:/bin")
+
+	profile := NewProfile(false)
+	profile.SetWithMode("PATH", "/opt/tools/bin", MergeAppend)
+
+	env.Merge(profile)
+	verifyValue(t, env, "PATH", "/usr/local/bin:/usr/bin:/bin:/opt/tools/bin")
+}
+
+func TestMergePrependAlreadyPresent(t *testing.T) {
+	env := NewProfile(false)
+	env.Set("PATH", "/home/user/venv/bin:/usr/local/bin:/usr/bin:/bin")
+
+	profile := NewProfile(false)
+	profile.SetWithMode("PATH", "/home/user/venv/bin", MergePrepend)
+
+	env.Merge(profile)
+	// Should be a no-op — component already exists
+	verifyValue(t, env, "PATH", "/home/user/venv/bin:/usr/local/bin:/usr/bin:/bin")
+}
+
+func TestMergeAppendAlreadyPresent(t *testing.T) {
+	env := NewProfile(false)
+	env.Set("PATH", "/usr/local/bin:/usr/bin:/opt/tools/bin")
+
+	profile := NewProfile(false)
+	profile.SetWithMode("PATH", "/opt/tools/bin", MergeAppend)
+
+	env.Merge(profile)
+	// No-op
+	verifyValue(t, env, "PATH", "/usr/local/bin:/usr/bin:/opt/tools/bin")
+}
+
+func TestMergePrependMultipleComponents(t *testing.T) {
+	env := NewProfile(false)
+	env.Set("PATH", "/usr/bin:/bin")
+
+	profile := NewProfile(false)
+	profile.SetWithMode("PATH", "/a:/b", MergePrepend)
+
+	env.Merge(profile)
+	verifyValue(t, env, "PATH", "/a:/b:/usr/bin:/bin")
+}
+
+func TestMergePrependPartialOverlap(t *testing.T) {
+	env := NewProfile(false)
+	env.Set("PATH", "/a:/usr/bin:/bin")
+
+	profile := NewProfile(false)
+	profile.SetWithMode("PATH", "/a:/new", MergePrepend)
+
+	env.Merge(profile)
+	// /a already exists, only /new should be prepended
+	verifyValue(t, env, "PATH", "/new:/a:/usr/bin:/bin")
+}
+
+func TestIsMergedPrepend(t *testing.T) {
+	env := NewProfile(false)
+	env.Set("PATH", "/home/user/venv/bin:/usr/local/bin:/usr/bin:/bin")
+
+	profile := NewProfile(false)
+	profile.SetWithMode("PATH", "/home/user/venv/bin", MergePrepend)
+
+	if !env.IsMerged(profile) {
+		t.Error("Profile should be considered merged — component is present in PATH")
+	}
+}
+
+func TestIsMergedPrependNotPresent(t *testing.T) {
+	env := NewProfile(false)
+	env.Set("PATH", "/usr/local/bin:/usr/bin:/bin")
+
+	profile := NewProfile(false)
+	profile.SetWithMode("PATH", "/home/user/venv/bin", MergePrepend)
+
+	if env.IsMerged(profile) {
+		t.Error("Profile should not be considered merged — component is missing from PATH")
+	}
+}
+
+func TestIsMergedAppendAnywhere(t *testing.T) {
+	env := NewProfile(false)
+	// Component is in the middle, not at the end — should still count as merged
+	env.Set("PATH", "/usr/local/bin:/opt/tools/bin:/usr/bin:/bin")
+
+	profile := NewProfile(false)
+	profile.SetWithMode("PATH", "/opt/tools/bin", MergeAppend)
+
+	if !env.IsMerged(profile) {
+		t.Error("Profile should be considered merged — component is present anywhere in PATH")
+	}
+}
+
+func TestMergeEmptyExisting(t *testing.T) {
+	env := NewProfile(false)
+	// PATH not set yet
+
+	profile := NewProfile(false)
+	profile.SetWithMode("PATH", "/new/bin", MergePrepend)
+
+	env.Merge(profile)
+	verifyValue(t, env, "PATH", "/new/bin")
+}
+
 func TestCaseInsensitive(t *testing.T) {
 	p := NewProfile(true)
 	p.Set("Hello", "world")

--- a/pkg/data/profile_test.go
+++ b/pkg/data/profile_test.go
@@ -1,8 +1,15 @@
 package data
 
 import (
+	"os"
+	"strings"
 	"testing"
 )
+
+// p joins path components with the platform path separator.
+func p(parts ...string) string {
+	return strings.Join(parts, string(os.PathListSeparator))
+}
 
 func verifyValue(t *testing.T, p *Profile, name string, value string) {
 	if v, ok := p.Get(name); !ok || value != v {
@@ -153,76 +160,76 @@ func TestFullDiffEmpty(t *testing.T) {
 
 func TestMergePrepend(t *testing.T) {
 	env := NewProfile(false)
-	env.Set("PATH", "/usr/local/bin:/usr/bin:/bin")
+	env.Set("PATH", p("/usr/local/bin", "/usr/bin", "/bin"))
 
 	profile := NewProfile(false)
 	profile.SetWithMode("PATH", "/home/user/venv/bin", MergePrepend)
 
 	env.Merge(profile)
-	verifyValue(t, env, "PATH", "/home/user/venv/bin:/usr/local/bin:/usr/bin:/bin")
+	verifyValue(t, env, "PATH", p("/home/user/venv/bin", "/usr/local/bin", "/usr/bin", "/bin"))
 }
 
 func TestMergeAppend(t *testing.T) {
 	env := NewProfile(false)
-	env.Set("PATH", "/usr/local/bin:/usr/bin:/bin")
+	env.Set("PATH", p("/usr/local/bin", "/usr/bin", "/bin"))
 
 	profile := NewProfile(false)
 	profile.SetWithMode("PATH", "/opt/tools/bin", MergeAppend)
 
 	env.Merge(profile)
-	verifyValue(t, env, "PATH", "/usr/local/bin:/usr/bin:/bin:/opt/tools/bin")
+	verifyValue(t, env, "PATH", p("/usr/local/bin", "/usr/bin", "/bin", "/opt/tools/bin"))
 }
 
 func TestMergePrependAlreadyPresent(t *testing.T) {
 	env := NewProfile(false)
-	env.Set("PATH", "/home/user/venv/bin:/usr/local/bin:/usr/bin:/bin")
+	env.Set("PATH", p("/home/user/venv/bin", "/usr/local/bin", "/usr/bin", "/bin"))
 
 	profile := NewProfile(false)
 	profile.SetWithMode("PATH", "/home/user/venv/bin", MergePrepend)
 
 	env.Merge(profile)
 	// Should be a no-op — component already exists
-	verifyValue(t, env, "PATH", "/home/user/venv/bin:/usr/local/bin:/usr/bin:/bin")
+	verifyValue(t, env, "PATH", p("/home/user/venv/bin", "/usr/local/bin", "/usr/bin", "/bin"))
 }
 
 func TestMergeAppendAlreadyPresent(t *testing.T) {
 	env := NewProfile(false)
-	env.Set("PATH", "/usr/local/bin:/usr/bin:/opt/tools/bin")
+	env.Set("PATH", p("/usr/local/bin", "/usr/bin", "/opt/tools/bin"))
 
 	profile := NewProfile(false)
 	profile.SetWithMode("PATH", "/opt/tools/bin", MergeAppend)
 
 	env.Merge(profile)
 	// No-op
-	verifyValue(t, env, "PATH", "/usr/local/bin:/usr/bin:/opt/tools/bin")
+	verifyValue(t, env, "PATH", p("/usr/local/bin", "/usr/bin", "/opt/tools/bin"))
 }
 
 func TestMergePrependMultipleComponents(t *testing.T) {
 	env := NewProfile(false)
-	env.Set("PATH", "/usr/bin:/bin")
+	env.Set("PATH", p("/usr/bin", "/bin"))
 
 	profile := NewProfile(false)
-	profile.SetWithMode("PATH", "/a:/b", MergePrepend)
+	profile.SetWithMode("PATH", p("/a", "/b"), MergePrepend)
 
 	env.Merge(profile)
-	verifyValue(t, env, "PATH", "/a:/b:/usr/bin:/bin")
+	verifyValue(t, env, "PATH", p("/a", "/b", "/usr/bin", "/bin"))
 }
 
 func TestMergePrependPartialOverlap(t *testing.T) {
 	env := NewProfile(false)
-	env.Set("PATH", "/a:/usr/bin:/bin")
+	env.Set("PATH", p("/a", "/usr/bin", "/bin"))
 
 	profile := NewProfile(false)
-	profile.SetWithMode("PATH", "/a:/new", MergePrepend)
+	profile.SetWithMode("PATH", p("/a", "/new"), MergePrepend)
 
 	env.Merge(profile)
 	// /a already exists, only /new should be prepended
-	verifyValue(t, env, "PATH", "/new:/a:/usr/bin:/bin")
+	verifyValue(t, env, "PATH", p("/new", "/a", "/usr/bin", "/bin"))
 }
 
 func TestIsMergedPrepend(t *testing.T) {
 	env := NewProfile(false)
-	env.Set("PATH", "/home/user/venv/bin:/usr/local/bin:/usr/bin:/bin")
+	env.Set("PATH", p("/home/user/venv/bin", "/usr/local/bin", "/usr/bin", "/bin"))
 
 	profile := NewProfile(false)
 	profile.SetWithMode("PATH", "/home/user/venv/bin", MergePrepend)
@@ -234,7 +241,7 @@ func TestIsMergedPrepend(t *testing.T) {
 
 func TestIsMergedPrependNotPresent(t *testing.T) {
 	env := NewProfile(false)
-	env.Set("PATH", "/usr/local/bin:/usr/bin:/bin")
+	env.Set("PATH", p("/usr/local/bin", "/usr/bin", "/bin"))
 
 	profile := NewProfile(false)
 	profile.SetWithMode("PATH", "/home/user/venv/bin", MergePrepend)
@@ -247,7 +254,7 @@ func TestIsMergedPrependNotPresent(t *testing.T) {
 func TestIsMergedAppendAnywhere(t *testing.T) {
 	env := NewProfile(false)
 	// Component is in the middle, not at the end — should still count as merged
-	env.Set("PATH", "/usr/local/bin:/opt/tools/bin:/usr/bin:/bin")
+	env.Set("PATH", p("/usr/local/bin", "/opt/tools/bin", "/usr/bin", "/bin"))
 
 	profile := NewProfile(false)
 	profile.SetWithMode("PATH", "/opt/tools/bin", MergeAppend)

--- a/pkg/ini/ini.go
+++ b/pkg/ini/ini.go
@@ -13,9 +13,18 @@ const (
 	typeString
 )
 
+// Operator indicates how a variable value should be applied.
+const (
+	OpReplace = iota // name=value (default)
+	OpPrepend        // name^=value
+	OpAppend         // name+=value
+)
+
+
 type Variable struct {
-	varType int
+	varType  int
 	value    string
+	Operator int // OpReplace, OpPrepend, or OpAppend
 }
 
 type Section struct {
@@ -50,26 +59,59 @@ func NewIni(path string) (*IniFile, error) {
 			sectionName = string(bytes.TrimSpace(line[1 : len(line)-1]))
 			continue
 		}
-		split := bytes.SplitN(line, []byte{'='}, 2)
-		varName := string(bytes.TrimSpace(split[0]))
-		varType := typeNil
-		varValue := ""
-		if len(split) == 2 {
-			varValue = string(bytes.TrimSpace(split[1]))
-			if len(varValue) == 0 {
-				varType = typeEmpty
-			} else {
-				varType = typeString
-			}
-		}
+		varName, varValue, varType, operator := parseLine(line)
 		section, ok := ini.sections[sectionName]
 		if !ok {
 			section = Section{variables: make(map[string]Variable)}
 			ini.sections[sectionName] = section
 		}
-		section.variables[varName] = Variable{varType: varType, value: varValue}
+		section.variables[varName] = Variable{varType: varType, value: varValue, Operator: operator}
 	}
 	return &ini, nil
+}
+
+// parseLine extracts variable name, value, type, and operator from an INI line.
+// Recognizes ^= (prepend), += (append), and = (replace).
+func parseLine(line []byte) (string, string, int, int) {
+	operator := OpReplace
+	// Check for ^= and += before falling back to =
+	if idx := bytes.Index(line, []byte("^=")); idx >= 0 {
+		operator = OpPrepend
+		name := string(bytes.TrimSpace(line[:idx]))
+		value := string(bytes.TrimSpace(line[idx+2:]))
+		if len(value) == 0 {
+			return name, "", typeEmpty, operator
+		}
+		return name, value, typeString, operator
+	}
+	if idx := bytes.Index(line, []byte("+=")); idx >= 0 {
+		operator = OpAppend
+		name := string(bytes.TrimSpace(line[:idx]))
+		value := string(bytes.TrimSpace(line[idx+2:]))
+		if len(value) == 0 {
+			return name, "", typeEmpty, operator
+		}
+		return name, value, typeString, operator
+	}
+	split := bytes.SplitN(line, []byte{'='}, 2)
+	varName := string(bytes.TrimSpace(split[0]))
+	if len(split) == 2 {
+		varValue := string(bytes.TrimSpace(split[1]))
+		if len(varValue) == 0 {
+			return varName, "", typeEmpty, OpReplace
+		}
+		return varName, varValue, typeString, OpReplace
+	}
+	return varName, "", typeNil, OpReplace
+}
+
+// GetOperator returns the operator for a variable (OpReplace, OpPrepend, or OpAppend).
+func (iniFile *IniFile) GetOperator(section string, name string) int {
+	v, ok := iniFile.getVariable(section, name)
+	if !ok {
+		return OpReplace
+	}
+	return v.Operator
 }
 
 // GetString Read string variable from a section

--- a/pkg/ini/ini_test.go
+++ b/pkg/ini/ini_test.go
@@ -139,3 +139,53 @@ func TestReadConfig(t *testing.T) {
 		}
 	}
 }
+
+const testOperatorConfig = `
+[profile:venv]
+PATH^=/home/user/venv/bin
+VIRTUAL_ENV=/home/user/venv
+
+[profile:tools]
+PATH+=/opt/tools/bin
+
+[profile:replace]
+PATH=/custom/only
+`
+
+func TestOperators(t *testing.T) {
+	file, err := ioutil.TempFile("", "config")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+	file.WriteString(testOperatorConfig)
+	file.Close()
+
+	ini, err := NewIni(file.Name())
+	if err != nil {
+		t.Fatal("Failed to read configuration")
+	}
+
+	// ^= should parse as prepend
+	checkString(t, ini, "profile:venv", "PATH", "/home/user/venv/bin")
+	if op := ini.GetOperator("profile:venv", "PATH"); op != OpPrepend {
+		t.Errorf("Expected OpPrepend for PATH^=, got %d", op)
+	}
+
+	// Regular = should still work
+	checkString(t, ini, "profile:venv", "VIRTUAL_ENV", "/home/user/venv")
+	if op := ini.GetOperator("profile:venv", "VIRTUAL_ENV"); op != OpReplace {
+		t.Errorf("Expected OpReplace for VIRTUAL_ENV=, got %d", op)
+	}
+
+	// += should parse as append
+	checkString(t, ini, "profile:tools", "PATH", "/opt/tools/bin")
+	if op := ini.GetOperator("profile:tools", "PATH"); op != OpAppend {
+		t.Errorf("Expected OpAppend for PATH+=, got %d", op)
+	}
+
+	// Plain = should be replace
+	if op := ini.GetOperator("profile:replace", "PATH"); op != OpReplace {
+		t.Errorf("Expected OpReplace for PATH=, got %d", op)
+	}
+}


### PR DESCRIPTION
- Add ^= (prepend) and += (append) operators for PATH-like variables in profile config, so profiles specify deltas instead of full paths
- Components already present anywhere in the path are skipped (no-op)
- Improved set command output: single "Already active" line for profiles with no effect, warning when path components were skipped
- Active profile detection uses contains-check for prepend/append vars