### PR TITLE
Fix application type on windows

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,10 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - -s -w -X github.com/sverrirab/envirou/cmd.Version={{.Version}}
+    overrides:
+      - goos: windows
+        ldflags:
+          - -s -w -X github.com/sverrirab/envirou/cmd.Version={{.Version}} -H windowsconsole
     goos:
       - linux
       - darwin


### PR DESCRIPTION
The application needs to be tagged as a console app to prevent warnings