### PR TITLE
Harden variable name validation against shell injection

### DIFF
--- a/cmd/dotenv.go
+++ b/cmd/dotenv.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/sverrirab/envirou/pkg/data"
 	"github.com/sverrirab/envirou/pkg/output"
+	"github.com/sverrirab/envirou/pkg/shell"
 )
 
 var dotenvCmd = &cobra.Command{
@@ -48,11 +49,18 @@ func loadDotenvFile(filename string, env *data.Profile) error {
 
 	var lines []string
 	scanner := bufio.NewScanner(file)
+	lineNum := 0
 	for scanner.Scan() {
+		lineNum++
 		line := parseDotenvLine(scanner.Text())
-		if line != "" {
-			lines = append(lines, line)
+		if line == "" {
+			continue
 		}
+		key := line[:strings.Index(line, "=")]
+		if !shell.IsValidVarName(key) {
+			return fmt.Errorf("line %d: invalid variable name %q", lineNum, key)
+		}
+		lines = append(lines, line)
 	}
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("failed reading file (%s)", err.Error())

--- a/cmd/dotenv_test.go
+++ b/cmd/dotenv_test.go
@@ -1,6 +1,12 @@
 package cmd
 
-import "testing"
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/sverrirab/envirou/pkg/data"
+)
 
 func TestParseDotenvLine(t *testing.T) {
 	tests := []struct {
@@ -45,6 +51,46 @@ func TestParseDotenvLine(t *testing.T) {
 				t.Errorf("parseDotenvLine(%q) = %q, want %q", tt.input, got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestParseDotenvLineRejectsInjection(t *testing.T) {
+	// parseDotenvLine itself just parses, but these would be caught by loadDotenvFile validation
+	// Verify the keys that come out of parseDotenvLine for dangerous patterns
+	injections := []struct {
+		input string
+		key   string
+	}{
+		{"FOO;rm -rf ~=value", "FOO;rm -rf ~"},
+		{"$(evil)=value", "$(evil)"},
+		{"`id`=value", "`id`"},
+		{"A B=value", "A B"},
+	}
+	for _, tt := range injections {
+		line := parseDotenvLine(tt.input)
+		if line == "" {
+			continue
+		}
+		// The key extracted should fail IsValidVarName (tested via loadDotenvFile)
+		key := line[:strings.Index(line, "=")]
+		if key != tt.key {
+			t.Errorf("parseDotenvLine(%q) key = %q, want %q", tt.input, key, tt.key)
+		}
+	}
+}
+
+func TestLoadDotenvFileRejectsInvalidName(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := tmpDir + "/bad.env"
+	os.WriteFile(path, []byte("GOOD=ok\nBAD;whoami=evil\n"), 0644)
+
+	env := data.NewProfile(false)
+	err := loadDotenvFile(path, env)
+	if err == nil {
+		t.Fatal("expected error for invalid variable name")
+	}
+	if !strings.Contains(err.Error(), "invalid variable name") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sverrirab/envirou/pkg/data"
 	"github.com/sverrirab/envirou/pkg/ini"
 	"github.com/sverrirab/envirou/pkg/output"
+	"github.com/sverrirab/envirou/pkg/shell"
 )
 
 type Configuration struct {
@@ -89,6 +90,10 @@ func ReadConfiguration(configPath string, caseInsensitive bool) (*Configuration,
 			profileName := strings.TrimSpace(split[1])
 			profile := data.NewProfile(caseInsensitive)
 			for _, entry := range config.GetAllVariables(section) {
+				if !shell.IsValidVarName(entry) {
+					output.Printf("Warning: skipping invalid variable name %q in [%s]\n", entry, section)
+					continue
+				}
 				if config.IsNil(section, entry) {
 					profile.SetNil(entry)
 				} else {

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -19,6 +19,33 @@ func NewShell(powerShell bool, bat bool) *Shell {
 	}
 }
 
+// IsValidVarName checks whether name is a safe environment variable identifier.
+// Only allows POSIX-portable names: [a-zA-Z_][a-zA-Z0-9_]*
+func IsValidVarName(name string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	c := name[0]
+	if !isLetter(c) && c != '_' {
+		return false
+	}
+	for i := 1; i < len(name); i++ {
+		c = name[i]
+		if !isLetter(c) && !isDigit(c) && c != '_' {
+			return false
+		}
+	}
+	return true
+}
+
+func isLetter(c byte) bool {
+	return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')
+}
+
+func isDigit(c byte) bool {
+	return '0' <= c && c <= '9'
+}
+
 func needsEscape(value string) bool {
 	for i := 0; i < len(value); i++ {
 		c := value[i]
@@ -73,6 +100,9 @@ func (shell *Shell) Escape(value string) string {
 }
 
 func (shell *Shell) ExportVar(name, value string) string {
+	if !IsValidVarName(name) {
+		return ""
+	}
 	if shell.powerShell {
 		return fmt.Sprintf("$Env:%s = %s", name, shell.Escape(value))
 	} else if shell.bat {
@@ -83,6 +113,9 @@ func (shell *Shell) ExportVar(name, value string) string {
 }
 
 func (shell *Shell) UnsetVar(name string) string {
+	if !IsValidVarName(name) {
+		return ""
+	}
 	if shell.powerShell {
 		return fmt.Sprintf("Remove-Item Env:%s", name)
 	} else if shell.bat {
@@ -111,10 +144,14 @@ func (shell *Shell) GetCommands(old, new *data.Profile) (commands []string) {
 	added, removed := old.Diff(new)
 	for _, add := range added {
 		value, _ := new.Get(add)
-		commands = append(commands, shell.ExportVar(add, value))
+		if cmd := shell.ExportVar(add, value); cmd != "" {
+			commands = append(commands, cmd)
+		}
 	}
 	for _, remove := range removed {
-		commands = append(commands, shell.UnsetVar(remove))
+		if cmd := shell.UnsetVar(remove); cmd != "" {
+			commands = append(commands, cmd)
+		}
 	}
 	return
 }

--- a/pkg/shell/shell_test.go
+++ b/pkg/shell/shell_test.go
@@ -27,6 +27,61 @@ func validateUnEscaped(t *testing.T, s string) {
 	}
 }
 
+func TestIsValidVarName(t *testing.T) {
+	valid := []string{"FOO", "BAR_BAZ", "_private", "a", "A1", "PATH", "__", "_0"}
+	for _, name := range valid {
+		if !IsValidVarName(name) {
+			t.Errorf("expected %q to be valid", name)
+		}
+	}
+	invalid := []string{
+		"",
+		"0FOO",
+		"FOO BAR",
+		"FOO;BAR",
+		"FOO;rm -rf ~",
+		"$(cmd)",
+		"`cmd`",
+		"FOO=BAR",
+		"FOO\nBAR",
+		"a-b",
+		"a.b",
+		"FOO$HOME",
+	}
+	for _, name := range invalid {
+		if IsValidVarName(name) {
+			t.Errorf("expected %q to be invalid", name)
+		}
+	}
+}
+
+func TestExportVarRejectsInvalidName(t *testing.T) {
+	for _, ps := range []bool{false, true} {
+		sh := NewShell(ps, false)
+		if cmd := sh.ExportVar("VALID", "value"); cmd == "" {
+			t.Error("expected command for valid name")
+		}
+		if cmd := sh.ExportVar("BAD;rm -rf /", "value"); cmd != "" {
+			t.Errorf("expected empty for injected name, got %q", cmd)
+		}
+		if cmd := sh.ExportVar("$(evil)", "value"); cmd != "" {
+			t.Errorf("expected empty for subshell name, got %q", cmd)
+		}
+	}
+}
+
+func TestUnsetVarRejectsInvalidName(t *testing.T) {
+	for _, ps := range []bool{false, true} {
+		sh := NewShell(ps, false)
+		if cmd := sh.UnsetVar("VALID"); cmd == "" {
+			t.Error("expected command for valid name")
+		}
+		if cmd := sh.UnsetVar("BAD;rm -rf /"); cmd != "" {
+			t.Errorf("expected empty for injected name, got %q", cmd)
+		}
+	}
+}
+
 func TestEscape(t *testing.T) {
 	validateEscaped(t, "hello world")
 	validateEscaped(t, "$hi")


### PR DESCRIPTION
Untrusted config or .env files could inject arbitrary shell commands via crafted variable names (e.g. "FOO;rm -rf ~") since the ev shell function uses eval on stdout. Variable values were already escaped but names were interpolated raw into export/unset commands.

Defense in depth at three layers:
- shell.IsValidVarName enforces POSIX [a-zA-Z_][a-zA-Z0-9_]*
- ExportVar/UnsetVar reject invalid names (last line of defense)
- dotenv parser returns error, config loader warns and skips